### PR TITLE
fix github stats

### DIFF
--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -8,9 +8,7 @@ cascade = [
     { showWordCount = false },
     { showTaxonomies = false }
 ]
-githubStatsUrl = 'https://github-readme-stats.vercel.app/api?username=k-capehart&show_icons=true&theme=dark&hide_rank=true'
+githubStatsUrl = 'https://github-readme-stats-five-mu-27.vercel.app/api?username=k-capehart&show_icons=true&theme=dark&hide_rank=true'
 githubUrl = 'https://github.com/k-capehart'
 resumeUrl = 'https://rawcdn.githack.com/k-capehart/resume/3bd7d1ea25616d061abda7050e693f069c8314c4/kyle_capehart_resume.pdf'
 +++
-
-[![Kyle's GitHub stats](https://github-readme-stats.vercel.app/api?username=k-capehart)](https://github.com/k-capehart/github-readme-stats)


### PR DESCRIPTION
- fix github stats by deploying own vercel instance
- forked repo with instructions: https://github.com/k-capehart/github-readme-stats?tab=readme-ov-file#on-vercel

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Point GitHub stats to a self-hosted Vercel endpoint and remove the embedded stats image from the projects page.
> 
> - **Content › `content/projects/_index.md`**:
>   - Update `githubStatsUrl` to self-hosted endpoint `github-readme-stats-five-mu-27.vercel.app`.
>   - Remove inline GitHub stats image from page body.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac87dd4b083664f3f3696ea4c852839b4f0e65fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->